### PR TITLE
Fix incorrect use of printf in visibility.c

### DIFF
--- a/visibility/src/visibility.c
+++ b/visibility/src/visibility.c
@@ -135,7 +135,7 @@ long input()
 		npts++;
 	}
 	if (npts < 1){
-		printf(stderr,"Error, no data read!");
+		fprintf(stderr,"Error, no data read!");
 		exit(-1);
 	}
 	return (npts);


### PR DESCRIPTION

The following error message is shown if the input is empty:

    printf(stderr,"Error, no data read!");

Clearly this is meant to be fprintf, not printf. :)
